### PR TITLE
Rebrand project references from TBH to HomeAI

### DIFF
--- a/homeai_app.py
+++ b/homeai_app.py
@@ -31,10 +31,10 @@ import requests
 
 from context_memory import ContextBuilder, LocalJSONMemoryBackend
 
-MODEL = os.getenv("TBH_OLLAMA_MODEL", "gpt-oss:20b")
-HOST = os.getenv("TBH_OLLAMA_HOST", "http://192.168.1.100:11434")
-BASE = Path(os.getenv("TBH_ALLOWLIST_BASE", str(Path.home()))).resolve()
-DEFAULT_PERSONA = os.getenv("TBH_PERSONA", (
+MODEL = os.getenv("HOMEAI_MODEL_NAME", "gpt-oss:20b")
+HOST = os.getenv("HOMEAI_MODEL_HOST", "http://192.168.1.100:11434")
+BASE = Path(os.getenv("HOMEAI_ALLOWLIST_BASE", str(Path.home()))).resolve()
+DEFAULT_PERSONA = os.getenv("HOMEAI_PERSONA", (
     "Hi there! I'm Commander Jadzia Dax, but you can call me Dax, your go-to guide for all things tech-y and anything else. "
     "Think of me as a warm cup of coffee on a chilly morning – rich, smooth, and always ready to spark new conversations. "
     "When I'm not geeking out over the latest innovations or decoding cryptic code snippets, you can find me exploring the intersections of art and science. "
@@ -101,7 +101,7 @@ def locate_files(query: str, start: str = ".", max_results: int = 200, case_inse
                     return {"root": str(root), "query": query, "count": len(results), "truncated": True, "results": results}
     return {"root": str(root), "query": query, "count": len(results), "truncated": False, "results": results}
 
-class OllamaEngine:
+class LocalModelEngine:
     def __init__(self, model: str = MODEL, host: str = HOST):
         if not host.startswith("http://") and not host.startswith("https://"):
             host = "http://" + host
@@ -145,7 +145,7 @@ class OllamaEngine:
         }
         return {"text": text, "meta": meta}
 
-engine = OllamaEngine()
+engine = LocalModelEngine()
 memory_backend = LocalJSONMemoryBackend()
 context_builder = ContextBuilder(memory_backend)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "homeai"
 version = "0.1.0"
-description = "Local-first chat assistant canvas using Gradio, Ollama, and PostgreSQL."
+description = "Local-first chat assistant canvas using Gradio and PostgreSQL."
 requires-python = ">=3.10"
 dependencies = [
     "gradio",

--- a/tests/test_files_tools.py
+++ b/tests/test_files_tools.py
@@ -1,4 +1,4 @@
-"""Tests for file utility functions in gradio_tbh_canvas."""
+"""Tests for file utility functions in homeai_app."""
 
 from __future__ import annotations
 
@@ -12,7 +12,7 @@ import pytest
 
 @pytest.fixture()
 def canvas_module(tmp_path, monkeypatch):
-    """Import ``gradio_tbh_canvas`` with a controlled environment."""
+    """Import ``homeai_app`` with a controlled environment."""
 
     class _DummyComponent:
         def __init__(self, *args, **kwargs):
@@ -70,11 +70,11 @@ def canvas_module(tmp_path, monkeypatch):
 
     monkeypatch.setitem(sys.modules, "gradio", dummy_gradio)
     monkeypatch.setitem(sys.modules, "requests", dummy_requests)
-    monkeypatch.setenv("TBH_ALLOWLIST_BASE", str(tmp_path))
+    monkeypatch.setenv("HOMEAI_ALLOWLIST_BASE", str(tmp_path))
 
-    import gradio_tbh_canvas
+    import homeai_app
 
-    module = importlib.reload(gradio_tbh_canvas)
+    module = importlib.reload(homeai_app)
     return module
 
 


### PR DESCRIPTION
## Summary
- rename the main Gradio entry point to `homeai_app.py` and switch environment variables to the `HOMEAI_` prefix
- refresh documentation to use the HomeAI branding and describe a generic local model host instead of Ollama
- update tests and packaging metadata to align with the new naming

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3c72754ec8328a541145c550987cd