### PR TITLE
Fix corrupt memory quarantine helper and add test

### DIFF
--- a/context_memory.py
+++ b/context_memory.py
@@ -106,7 +106,7 @@ class LocalJSONMemoryBackend:
             return existing[-1].stem
         return "conversation"
 
-    def _quarantine_corrupt(path: Path, exc: Exception) -> None:
+    def _quarantine_corrupt(self, path: Path, exc: Exception) -> None:
         ts = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
         quarantined = path.with_suffix(path.suffix + f".corrupt-{ts}")
         try:
@@ -127,7 +127,7 @@ class LocalJSONMemoryBackend:
             raw = json.loads(path.read_text(encoding="utf-8"))
             return [MemoryMessage(**msg) for msg in raw]
         except json.JSONDecodeError as e:
-            _quarantine_corrupt(path, e)
+            self._quarantine_corrupt(path, e)
             return []
 
     # ------------------------------------------------------------------

--- a/tests/test_context_memory.py
+++ b/tests/test_context_memory.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+from context_memory import LocalJSONMemoryBackend
+
+
+def test_load_messages_quarantines_corrupt_file(tmp_path: Path) -> None:
+    backend = LocalJSONMemoryBackend(base_dir=tmp_path)
+    conversation_id = "conversation"
+    path = backend._conversation_path(conversation_id)
+    path.write_text("{ invalid json", encoding="utf-8")
+
+    messages = backend._load_messages(conversation_id)
+
+    assert messages == []
+    assert not path.exists()
+    quarantined = list(tmp_path.glob("conversation.json.corrupt-*"))
+    assert len(quarantined) == 1


### PR DESCRIPTION
## Summary
- ensure the corrupt-file quarantine helper on `LocalJSONMemoryBackend` is called through the instance so it can be reused
- add regression coverage verifying that invalid JSON files are quarantined without raising errors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3f1032bac8328ab4cc6b264d6f518