### PR TITLE
Fix UTC import for Python 3.10 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ HomeAI is a local-first chat assistant that runs on your machine using **Gradio*
 - **Memory** (JSON/optional Postgres): disk-backed message store with retrieval-ready context builder
   - Defaults to a local JSON backend (`~/.homeai/memory`) for quick-start setups
   - Swap in Postgres for production usage with `tsvector` FTS and pgvector HNSW when available
+  - Uses standard-library `timezone.utc` timestamps so the fallback backend works on Python 3.10+
 - **Agentic-ready**: structured outputs/tool calling loop (plan → tool → observe → continue)
 
 ---

--- a/context_memory.py
+++ b/context_memory.py
@@ -23,7 +23,7 @@ import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Sequence
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 import os, tempfile, shutil
 
 def _sanitize_id(s: str) -> str:
@@ -111,7 +111,7 @@ class LocalJSONMemoryBackend:
         return "conversation"
 
     def _quarantine_corrupt(self, path: Path, exc: Exception) -> None:
-        ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
         quarantined = path.with_suffix(path.suffix + f".corrupt-{ts}")
         try:
             shutil.move(str(path), str(quarantined))


### PR DESCRIPTION
## Summary
- replace the datetime.UTC import with timezone.utc so the local JSON memory backend works on Python 3.10
- document the timezone handling in the README for the fallback memory backend

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e408600b688328903cc53912d5c7ba