### PR TITLE
Add psql dependency docs and tests for bootstrap script

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ HomeAI is a local-first chat assistant that runs on your machine using **Gradio*
 - **GPU**: NVIDIA RTX 4090 (24 GB VRAM recommended for `gpt-oss:20b`)
 - **Local model host**: expose `/api/chat` (and optionally `/api/generate`)
 - **PostgreSQL**: 16+ with `pgvector` and `pg_trgm`
+- **psql client tools**: e.g., `postgresql-client` so the bootstrap script can run
 - **Fooocus** (optional): running locally via its UI or a small REST shim
 
 ---
@@ -62,6 +63,7 @@ See `docs/postgresql_setup.md` for a detailed walkthrough of preparing PostgreSQ
 sudo apt update
 sudo apt install -y postgresql postgresql-contrib postgresql-16-pgvector
 sudo -u postgres psql
+# If your distro separates the CLI tools, also install the `postgresql-client` package for `psql`.
 ```
 
 In `psql`:

--- a/tests/test_bootstrap_postgres_script.py
+++ b/tests/test_bootstrap_postgres_script.py
@@ -1,0 +1,56 @@
+import os
+import subprocess
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / "scripts" / "bootstrap_postgres.sh"
+
+
+def run_script(env):
+    result = subprocess.run(
+        ["/bin/bash", str(SCRIPT_PATH)],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    return result
+
+
+def test_bootstrap_requires_psql(tmp_path):
+    env = os.environ.copy()
+    env["PATH"] = str(tmp_path)
+
+    result = run_script(env)
+
+    assert result.returncode != 0
+    assert "psql command not found" in result.stderr
+
+
+def test_bootstrap_invokes_psql_with_defaults(tmp_path):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log_file = tmp_path / "psql.log"
+
+    stub_script = bin_dir / "psql"
+    stub_script.write_text(
+        "#!/usr/bin/env bash\n"
+        f"echo \"$0 $@\" >> '{log_file}'\n"
+        "cat >/dev/null\n"
+    )
+    stub_script.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"
+    env.pop("PGPASSWORD", None)
+
+    result = run_script(env)
+
+    assert result.returncode == 0, result.stderr
+    log_contents = log_file.read_text().strip().splitlines()
+
+    assert len(log_contents) == 2
+    for line in log_contents:
+        assert "--username=postgres" in line
+        assert "--host=localhost" in line
+        assert "--port=5432" in line
+        assert "--dbname=postgres" in line
+


### PR DESCRIPTION
## Summary
- document the requirement for the psql client tools in the README quick start and requirements sections
- add regression tests for scripts/bootstrap_postgres.sh to cover missing psql and successful invocation scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e44c65d8648328be0e329818e48604