### PR TITLE
Fix quoting for role password in bootstrap script

### DIFF
--- a/scripts/bootstrap_postgres.py
+++ b/scripts/bootstrap_postgres.py
@@ -134,14 +134,18 @@ def _ensure_role(cur, sql, config: BootstrapConfig) -> None:
     if not exists:
         _log(f"Creating role '{config.db_user}'...")
         cur.execute(
-            sql.SQL("CREATE ROLE {} LOGIN PASSWORD %s").format(sql.Identifier(config.db_user)),
-            (config.db_password,),
+            sql.SQL("CREATE ROLE {} LOGIN PASSWORD {}").format(
+                sql.Identifier(config.db_user),
+                sql.Literal(config.db_password),
+            )
         )
     else:
         _log(f"Updating password for role '{config.db_user}'...")
         cur.execute(
-            sql.SQL("ALTER ROLE {} WITH LOGIN PASSWORD %s").format(sql.Identifier(config.db_user)),
-            (config.db_password,),
+            sql.SQL("ALTER ROLE {} WITH LOGIN PASSWORD {}").format(
+                sql.Identifier(config.db_user),
+                sql.Literal(config.db_password),
+            )
         )
 
 


### PR DESCRIPTION
## Summary
- embed role password values as SQL literals when creating or updating the HomeAI role
- avoid PostgreSQL syntax errors when altering role passwords during bootstrap

## Testing
- python -m compileall scripts/bootstrap_postgres.py

------
https://chatgpt.com/codex/tasks/task_e_68e455d8bca883288a36369296e074b9