### PR TITLE
Ensure PostgreSQL bootstrap creates memory schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HomeAI Canvas — Local Chat, Files, and Memory
 
-HomeAI is a local-first chat assistant that runs on your machine using **Gradio** for UI, a configurable **local model host** (default model tag: `gpt-oss:20b`), and **PostgreSQL** for durable chat history, memories, and retrieval (FTS + pgvector). Optional tools include file browsing/reading and image generation via local Fooocus.
+HomeAI is a local-first chat assistant that runs on your machine using **Gradio** for UI, a configurable **local model host** (default model tag: `gpt-oss:20b`), and an optional **PostgreSQL** backend for durable chat history, memories, and retrieval (FTS + pgvector). Optional tools include file browsing/reading and image generation via local Fooocus. See [`docs/postgresql_setup.md`](docs/postgresql_setup.md) for detailed PostgreSQL setup instructions.
 
 ## Features
 
@@ -22,7 +22,7 @@ HomeAI is a local-first chat assistant that runs on your machine using **Gradio*
 - **Python**: 3.10+
 - **GPU**: NVIDIA RTX 4090 (24 GB VRAM recommended for `gpt-oss:20b`)
 - **Local model host**: expose `/api/chat` (and optionally `/api/generate`)
-- **PostgreSQL**: 16+ with `pgvector` and `pg_trgm`
+- **PostgreSQL** (optional): 16+ with `pgvector` and `pg_trgm`
 - **psql client tools**: e.g., `postgresql-client` so the bootstrap script can run
 - **Fooocus** (optional): running locally via its UI or a small REST shim
 
@@ -55,9 +55,9 @@ export HOMEAI_MODEL_NAME=gpt-oss:20b
 export HOMEAI_ALLOWLIST_BASE="$HOME"
 ```
 
-### 3) PostgreSQL + extensions
+### 3) PostgreSQL + extensions (optional)
 
-See `docs/postgresql_setup.md` for a detailed walkthrough of preparing PostgreSQL on Ubuntu, including a reusable bootstrap script. Minimal outline:
+See [`docs/postgresql_setup.md`](docs/postgresql_setup.md) for a detailed walkthrough of preparing PostgreSQL on Ubuntu, including a reusable bootstrap script. Minimal outline:
 
 ```bash
 sudo apt update

--- a/docs/postgresql_setup.md
+++ b/docs/postgresql_setup.md
@@ -76,6 +76,7 @@ Add `--dry-run` (or set `HOMEAI_BOOTSTRAP_DRY_RUN=1`) to preview the actions wit
 | `HOMEAI_DB_NAME` | Application database name | `homeai` |
 | `HOMEAI_DB_USER` | Application role | `homeai` |
 | `HOMEAI_DB_PASSWORD` | Application role password | `homeai_password` |
+| `HOMEAI_PG_SCHEMA` | Optional schema where HomeAI tables should live (also accepts `HOMEAI_DB_SCHEMA`) | *(empty)* |
 | `HOMEAI_SCHEMA_FILE` | Path to an SQL file that should be applied after creation | *(empty)* |
 | `HOMEAI_BOOTSTRAP_DRY_RUN` | When set to a truthy value, only log the planned actions | `false` |
 
@@ -95,7 +96,7 @@ HOMEAI_DB_PASSWORD='supersecret' \
 python scripts/bootstrap_postgres.py
 ```
 
-If you want to seed the database with a schema file:
+The bootstrapper automatically creates (or updates) the `homeai_memory` table and supporting indexes used by the application’s PostgreSQL backend, ensuring it matches the read/write logic in the codebase. If you want to seed the database with a schema file (for additional tables or extensions):
 
 ```bash
 HOMEAI_SCHEMA_FILE=sql/schema.sql python scripts/bootstrap_postgres.py


### PR DESCRIPTION
## Summary
- extend the PostgreSQL bootstrap script to provision the HomeAI memory table, optional schema, and supporting indexes
- log dry-run details for schema/table creation and gracefully skip FTS index creation when unavailable
- document PostgreSQL as an optional backend in the README and expand the setup guide with new bootstrap behaviour

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e4667cb95883289d3403ebe0a37f21