### PR TITLE
Fix bootstrap memory table SQL placeholder

### DIFF
--- a/scripts/bootstrap_postgres.py
+++ b/scripts/bootstrap_postgres.py
@@ -192,7 +192,7 @@ def _ensure_application_objects(psycopg, sql, config: BootstrapConfig) -> None:
                             user_id TEXT NULL,
                             session_id TEXT NOT NULL,
                             tags JSONB NOT NULL DEFAULT '[]'::jsonb,
-                            content JSONB NOT NULL DEFAULT '{}'::jsonb,
+                            content JSONB NOT NULL DEFAULT '{{}}'::jsonb,
                             plain_text TEXT NOT NULL DEFAULT '',
                             created_at TIMESTAMPTZ NOT NULL,
                             updated_at TIMESTAMPTZ NOT NULL


### PR DESCRIPTION
## Summary
- escape curly braces in the bootstrap memory table DDL so psycopg.sql formatting no longer misinterprets them

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e469aa9890832891c763626852cae5