### PR TITLE
docs: update postgres setup examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,18 +81,33 @@ Apply the DDL from the canvas to create:
 - `conversations`, `messages`, `memories`
 - GIN FTS indexes and HNSW vector indexes
 
+To run the bootstrapper with explicit credentials in one line (non-interactive shells):
+
+```bash
+POSTGRES_SUPERUSER=postgres \
+POSTGRES_SUPERUSER_PASSWORD='your-postgres-password' \
+HOMEAI_DB_PASSWORD='your-app-password' \
+python scripts/bootstrap_postgres.py
+```
+
 DB connection env:
 
 ```bash
-export HOMEAI_DB_DSN=postgresql://homeai_user:change-me@127.0.0.1:5432/homeai_db
+export HOMEAI_PG_DSN=postgresql://homeai_user:change-me@127.0.0.1:5432/homeai_db
 # or via Unix socket:
-# export HOMEAI_DB_DSN=postgresql://homeai_user:change-me@/homeai_db?host=/var/run/postgresql
+# export HOMEAI_PG_DSN=postgresql://homeai_user:change-me@/homeai_db?host=/var/run/postgresql
 ```
 
 ### 4) Run the app
 
 ```bash
+# JSON (filesystem) memory backend
 python homeai_app.py
+
+# PostgreSQL memory backend
+HOMEAI_PG_DSN=postgresql://homeai_user:change-me@127.0.0.1:5432/homeai_db \
+  python homeai_app.py --storage=pg
+
 # UI opens at http://127.0.0.1:7860
 ```
 
@@ -126,7 +141,7 @@ The right-hand **LLM / Tool Log** shows raw request/response meta for each turn.
 ## Memory & Retrieval
 
 - Messages are stored in a **local JSON backend** by default (`~/.homeai/memory`).
-- When `HOMEAI_DB_DSN` is configured you can swap in a Postgres-backed backend with:
+- When `HOMEAI_PG_DSN` is configured (and `--storage=pg` or `HOMEAI_STORAGE=pg`) you can swap in a Postgres-backed backend with:
   - **FTS** (`tsvector` + GIN) for keywords/paths
   - **pgvector HNSW** for semantic recall
 - Embeddings are generated locally via the model host’s `/api/embeddings` endpoint (e.g., `nomic-embed-text`) and updated asynchronously when vector search is enabled.
@@ -149,7 +164,7 @@ Environment variables (common):
 HOMEAI_MODEL_HOST=http://127.0.0.1:11434
 HOMEAI_MODEL_NAME=gpt-oss:20b
 HOMEAI_ALLOWLIST_BASE=/home/youruser
-HOMEAI_DB_DSN=postgresql://homeai_user:change-me@127.0.0.1:5432/homeai_db
+HOMEAI_PG_DSN=postgresql://homeai_user:change-me@127.0.0.1:5432/homeai_db
 ```
 
 Optional:

--- a/docs/postgresql_setup.md
+++ b/docs/postgresql_setup.md
@@ -96,6 +96,13 @@ HOMEAI_DB_PASSWORD='supersecret' \
 python scripts/bootstrap_postgres.py
 ```
 
+For quick setups you can also run it in one line using the defaults for the role and database names:
+
+```bash
+POSTGRES_SUPERUSER=postgres POSTGRES_SUPERUSER_PASSWORD='supersecret' \
+HOMEAI_DB_PASSWORD='supersecret' python scripts/bootstrap_postgres.py
+```
+
 The bootstrapper automatically creates (or updates) the `homeai_memory` table and supporting indexes used by the application’s PostgreSQL backend, ensuring it matches the read/write logic in the codebase. If you want to seed the database with a schema file (for additional tables or extensions):
 
 ```bash
@@ -119,4 +126,9 @@ You should see the `homeai` user and database in the output.
 
 ## 6. Next steps
 
-Once the database is prepared you can point the application to it by configuring the appropriate environment variables (for example, `DATABASE_URL=postgresql://homeai:homeai_password@localhost:5432/homeai`).
+Once the database is prepared you can point the application to it by configuring the `HOMEAI_PG_DSN` environment variable and running the app with the PostgreSQL storage backend:
+
+```bash
+HOMEAI_PG_DSN=postgresql://homeai:homeai_password@127.0.0.1:5432/homeai \
+  python homeai_app.py --storage=pg
+```


### PR DESCRIPTION
## Summary
- document a one-line bootstrap invocation that exports the superuser and app credentials
- update runtime instructions to use HOMEAI_PG_DSN with the pg storage flag

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e47168f8688328912fc3e2fe33c1ba