### PR TITLE
Use HOMEAI_STORAGE env var for backend selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ python homeai_app.py
 
 # PostgreSQL memory backend
 HOMEAI_PG_DSN=postgresql://homeai_user:change-me@127.0.0.1:5432/homeai_db \
-  python homeai_app.py --storage=pg
+HOMEAI_STORAGE=pg \
+  python homeai_app.py
 
 # UI opens at http://127.0.0.1:7860
 ```
@@ -141,7 +142,7 @@ The right-hand **LLM / Tool Log** shows raw request/response meta for each turn.
 ## Memory & Retrieval
 
 - Messages are stored in a **local JSON backend** by default (`~/.homeai/memory`).
-- When `HOMEAI_PG_DSN` is configured (and `--storage=pg` or `HOMEAI_STORAGE=pg`) you can swap in a Postgres-backed backend with:
+- When `HOMEAI_PG_DSN` is configured (and `HOMEAI_STORAGE=pg`) you can swap in a Postgres-backed backend with:
   - **FTS** (`tsvector` + GIN) for keywords/paths
   - **pgvector HNSW** for semantic recall
 - Embeddings are generated locally via the model host’s `/api/embeddings` endpoint (e.g., `nomic-embed-text`) and updated asynchronously when vector search is enabled.

--- a/docs/postgresql_setup.md
+++ b/docs/postgresql_setup.md
@@ -130,5 +130,6 @@ Once the database is prepared you can point the application to it by configuring
 
 ```bash
 HOMEAI_PG_DSN=postgresql://homeai:homeai_password@127.0.0.1:5432/homeai \
-  python homeai_app.py --storage=pg
+HOMEAI_STORAGE=pg \
+  python homeai_app.py
 ```

--- a/homeai_app.py
+++ b/homeai_app.py
@@ -19,7 +19,6 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import argparse
 import os
 import json
 import time
@@ -153,9 +152,10 @@ context_builder: ContextBuilder
 
 def _init_memory_backend(*, storage: str | None = None) -> None:
     global memory_backend, context_builder
+    selected_storage = storage or os.getenv("HOMEAI_STORAGE")
     kwargs: Dict[str, Any] = {}
-    if storage:
-        kwargs["storage"] = storage
+    if selected_storage:
+        kwargs["storage"] = selected_storage
     memory_backend = LocalJSONMemoryBackend(**kwargs)
     context_builder = ContextBuilder(memory_backend)
 
@@ -439,15 +439,5 @@ with gr.Blocks(title="Local Chat (Files)") as demo:
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Run the HomeAI Gradio UI")
-    parser.add_argument(
-        "--storage",
-        choices=["fs", "pg"],
-        default=None,
-        help="Select the memory storage backend (fs=local JSON, pg=PostgreSQL placeholder).",
-    )
-    cli_args = parser.parse_args()
-    if cli_args.storage:
-        os.environ["HOMEAI_STORAGE"] = cli_args.storage
-    _init_memory_backend(storage=cli_args.storage)
+    _init_memory_backend()
     demo.launch(server_name="0.0.0.0", server_port=7860, show_error=True)


### PR DESCRIPTION
## Summary
- initialize the memory backend based on the HOMEAI_STORAGE environment variable instead of a CLI flag
- update README and PostgreSQL setup instructions to document the new configuration flow

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e5020f31d88328bf6f854db10605cb