### PR TITLE
Allow configuring context builder via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,15 @@ Optional:
 ```
 # Persona seed (first system message)
 HOMEAI_PERSONA="You are a single consistent assistant persona named 'Dax'..."
+
+# Conversation context shaping
+# (all values are integers; leave unset to keep defaults)
+HOMEAI_CONTEXT_RECENT_LIMIT=128          # 0 means "include entire stored chat"
+HOMEAI_CONTEXT_TOKEN_BUDGET=20000        # approximate total tokens allowed in prompt
+HOMEAI_CONTEXT_RESERVE_FOR_RESPONSE=1800 # tokens to save for the model reply
+HOMEAI_CONTEXT_FTS_LIMIT=10              # retrieved keyword matches per turn
+HOMEAI_CONTEXT_VECTOR_LIMIT=10           # retrieved semantic matches per turn
+HOMEAI_CONTEXT_MEMORY_LIMIT=8            # durable memory snippets per turn
 ```
 
 ---

--- a/tests/test_homeai_app.py
+++ b/tests/test_homeai_app.py
@@ -1,0 +1,17 @@
+import importlib
+
+
+def test_context_builder_env_overrides_parses_ints(monkeypatch):
+    homeai_app = importlib.import_module("homeai_app")
+
+    monkeypatch.setenv("HOMEAI_CONTEXT_RECENT_LIMIT", "64")
+    monkeypatch.setenv("HOMEAI_CONTEXT_TOKEN_BUDGET", " 20000 ")
+    monkeypatch.setenv("HOMEAI_CONTEXT_RESERVE_FOR_RESPONSE", "1800")
+    monkeypatch.setenv("HOMEAI_CONTEXT_FTS_LIMIT", "oops")  # ignored
+
+    overrides = homeai_app._context_builder_env_overrides()
+
+    assert overrides["recent_limit"] == 64
+    assert overrides["token_budget"] == 20000
+    assert overrides["reserve_for_response"] == 1800
+    assert "fts_limit" not in overrides


### PR DESCRIPTION
## Summary
- allow ContextBuilder configuration to be overridden with environment variables
- document the new tuning knobs for conversation context sizing
- add regression test to ensure environment overrides parsing works

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e505a942bc832891880923e2371dbb