### PR TITLE
Add modular slash command intent detection

### DIFF
--- a/tests/test_homeai_app.py
+++ b/tests/test_homeai_app.py
@@ -15,3 +15,48 @@ def test_context_builder_env_overrides_parses_ints(monkeypatch):
     assert overrides["token_budget"] == 20000
     assert overrides["reserve_for_response"] == 1800
     assert "fts_limit" not in overrides
+
+
+def test_detect_intent_supports_slash_read():
+    homeai_app = importlib.import_module("homeai_app")
+
+    intent, args = homeai_app.detect_intent("/read docs/file.txt")
+
+    assert intent == "read"
+    assert args == {"path": "docs/file.txt"}
+
+
+def test_detect_intent_slash_defaults_browse_path():
+    homeai_app = importlib.import_module("homeai_app")
+
+    intent, args = homeai_app.detect_intent("/ls")
+
+    assert intent == "browse"
+    assert args == {"path": "."}
+
+
+def test_detect_intent_slash_requires_keyword_without_whitespace():
+    homeai_app = importlib.import_module("homeai_app")
+
+    intent, args = homeai_app.detect_intent("/ locate something")
+
+    assert intent == "chat"
+    assert args == {}
+
+
+def test_detect_intent_handles_text_synonyms():
+    homeai_app = importlib.import_module("homeai_app")
+
+    intent, args = homeai_app.detect_intent("Summarise notes/today.md")
+
+    assert intent == "summarize"
+    assert args == {"path": "notes/today.md"}
+
+
+def test_detect_intent_unknown_slash_falls_back_to_chat():
+    homeai_app = importlib.import_module("homeai_app")
+
+    intent, args = homeai_app.detect_intent("/dance party time")
+
+    assert intent == "chat"
+    assert args == {}


### PR DESCRIPTION
## Summary
- refactor keyword intent detection to use a reusable command registry
- add support for slash-prefixed commands such as /read and /ls
- cover new behavior with tests for slash handling and synonym detection

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e52182b8cc8328bdcb0a3a0fdcb612