### PR TITLE
Handle slash commands with optional whitespace

### DIFF
--- a/homeai_app.py
+++ b/homeai_app.py
@@ -376,8 +376,10 @@ def detect_intent(text: str) -> Tuple[str, Dict[str, str]]:
         return "chat", {}
 
     # Slash command handling (e.g. "/read path/to/file").
-    if stripped.startswith("/") and len(stripped) > 1 and not stripped[1].isspace():
-        remainder = stripped[1:]
+    if stripped.startswith("/") and len(stripped) > 1:
+        remainder = stripped[1:].lstrip()
+        if not remainder:
+            return "chat", {}
         parts = remainder.split(None, 1)
         command = parts[0].lower()
         args_text = parts[1] if len(parts) > 1 else ""

--- a/tests/test_homeai_app.py
+++ b/tests/test_homeai_app.py
@@ -35,13 +35,22 @@ def test_detect_intent_slash_defaults_browse_path():
     assert args == {"path": "."}
 
 
-def test_detect_intent_slash_requires_keyword_without_whitespace():
+def test_detect_intent_slash_ignores_empty_command():
     homeai_app = importlib.import_module("homeai_app")
 
-    intent, args = homeai_app.detect_intent("/ locate something")
+    intent, args = homeai_app.detect_intent("/   ")
 
     assert intent == "chat"
     assert args == {}
+
+
+def test_detect_intent_slash_tolerates_space_after_slash():
+    homeai_app = importlib.import_module("homeai_app")
+
+    intent, args = homeai_app.detect_intent("/ read docs/file.txt")
+
+    assert intent == "read"
+    assert args == {"path": "docs/file.txt"}
 
 
 def test_detect_intent_handles_text_synonyms():


### PR DESCRIPTION
## Summary
- allow slash commands to ignore leading whitespace after the slash so `/ read` resolves correctly
- add regression tests covering empty slash commands and whitespace-tolerant parsing

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e5533c86888328b076546676ea28bc