### PR TITLE
Require slash-prefixed commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,10 @@ pytest
 Type into the chat input:
 
 - **Chat**: `what can you do?`
-- **Browse**: `browse ~` or `browse Documents`
-- **Read**: `read ~/notes/todo.txt`
-- **Summarize**: `summarize ~/projects/README.md`
-- **Locate**: `locate invoice` or `find photo_2024`
+- **Browse**: `/browse ~` or `/browse Documents`
+- **Read**: `/read ~/notes/todo.txt`
+- **Summarize**: `/summarize ~/projects/README.md`
+- **Locate**: `/locate invoice` or `/find photo_2024`
 
 The right-hand **LLM / Tool Log** shows raw request/response meta for each turn.
 

--- a/homeai_app.py
+++ b/homeai_app.py
@@ -355,29 +355,13 @@ COMMAND_SPECS: Tuple[CommandSpec, ...] = (
         parser=_parse_query_argument,
     ),
 )
-
-
-def _strip_leading_keyword(text: str, keyword: str) -> str:
-    return text[len(keyword) :].lstrip()
-
-
-def _matches_keyword(text: str, keyword: str) -> bool:
-    if not text.lower().startswith(keyword):
-        return False
-    if len(text) == len(keyword):
-        return True
-    next_char = text[len(keyword)]
-    return next_char.isspace()
-
-
 def detect_intent(text: str) -> Tuple[str, Dict[str, str]]:
-    stripped = text.strip()
-    if not stripped:
+    if not text:
         return "chat", {}
 
-    # Slash command handling (e.g. "/read path/to/file").
-    if stripped.startswith("/") and len(stripped) > 1:
-        remainder = stripped[1:].lstrip()
+    # Slash command handling requires the very first character to be "/".
+    if text[0] == "/":
+        remainder = text[1:].lstrip()
         if not remainder:
             return "chat", {}
         parts = remainder.split(None, 1)
@@ -388,11 +372,9 @@ def detect_intent(text: str) -> Tuple[str, Dict[str, str]]:
                 return spec.intent, spec.parser(args_text)
         return "chat", {}
 
-    for spec in COMMAND_SPECS:
-        for keyword in spec.keywords:
-            if _matches_keyword(stripped, keyword):
-                args_text = _strip_leading_keyword(stripped, keyword) if len(stripped) > len(keyword) else ""
-                return spec.intent, spec.parser(args_text)
+    stripped = text.strip()
+    if not stripped:
+        return "chat", {}
 
     return "chat", {}
 

--- a/tests/test_homeai_app.py
+++ b/tests/test_homeai_app.py
@@ -53,19 +53,28 @@ def test_detect_intent_slash_tolerates_space_after_slash():
     assert args == {"path": "docs/file.txt"}
 
 
-def test_detect_intent_handles_text_synonyms():
+def test_detect_intent_plain_text_treated_as_chat():
     homeai_app = importlib.import_module("homeai_app")
 
     intent, args = homeai_app.detect_intent("Summarise notes/today.md")
 
-    assert intent == "summarize"
-    assert args == {"path": "notes/today.md"}
+    assert intent == "chat"
+    assert args == {}
 
 
 def test_detect_intent_unknown_slash_falls_back_to_chat():
     homeai_app = importlib.import_module("homeai_app")
 
     intent, args = homeai_app.detect_intent("/dance party time")
+
+    assert intent == "chat"
+    assert args == {}
+
+
+def test_detect_intent_requires_slash_prefix_for_commands():
+    homeai_app = importlib.import_module("homeai_app")
+
+    intent, args = homeai_app.detect_intent("read docs/file.txt")
 
     assert intent == "chat"
     assert args == {}


### PR DESCRIPTION
## Summary
- require commands to begin with a slash before attempting keyword detection
- update tests to confirm plain text is treated as chat and slash commands still work
- document the slash-prefixed syntax in the README examples

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e55bec87108328b0eb43d9134a64c6