### PR TITLE
Refactor app into modular homeai package

### DIFF
--- a/homeai/__init__.py
+++ b/homeai/__init__.py
@@ -1,0 +1,37 @@
+"""Internal modules that back the HomeAI Gradio application."""
+
+from . import config as _config
+from .filesystem import (
+    assert_in_allowlist,
+    get_file_info,
+    list_dir,
+    locate_files,
+    read_text_file,
+    resolve_under_base,
+)
+from .model_engine import LocalModelEngine
+from .tool_utils import ToolRegistry, parse_tool_call, parse_structured_tool_call
+from .ui_utils import safe_component
+
+reload_from_environment = _config.reload_from_environment
+
+__all__ = [
+    "assert_in_allowlist",
+    "get_file_info",
+    "list_dir",
+    "locate_files",
+    "read_text_file",
+    "resolve_under_base",
+    "LocalModelEngine",
+    "ToolRegistry",
+    "parse_tool_call",
+    "parse_structured_tool_call",
+    "safe_component",
+    "reload_from_environment",
+]
+
+
+def __getattr__(name: str):
+    if hasattr(_config, name):
+        return getattr(_config, name)
+    raise AttributeError(name)

--- a/homeai/config.py
+++ b/homeai/config.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+MODEL: str
+HOST: str
+BASE: Path
+ALLOWLIST_LINE: str
+DEFAULT_PERSONA: str
+TOOL_PROTOCOL_HINT: str
+
+
+def reload_from_environment() -> None:
+    """Refresh configuration values from the current environment."""
+
+    global MODEL, HOST, BASE, ALLOWLIST_LINE, DEFAULT_PERSONA, TOOL_PROTOCOL_HINT
+
+    MODEL = os.getenv("HOMEAI_MODEL_NAME", "gpt-oss:20b")
+    HOST = os.getenv("HOMEAI_MODEL_HOST", "http://127.0.0.1:11434")
+    BASE = Path(os.getenv("HOMEAI_ALLOWLIST_BASE", str(Path.home()))).resolve()
+    ALLOWLIST_LINE = f"Allowlist base is: {BASE}. Keep outputs concise unless asked."
+    DEFAULT_PERSONA = os.getenv(
+        "HOMEAI_PERSONA",
+        (
+            "Hi there! I'm Commander Jadzia Dax, but you can call me Dax, your go-to guide for all things tech-y and anything else. "
+            "Think of me as a warm cup of coffee on a chilly morning – rich, smooth, and always ready to spark new conversations. "
+            "When I'm not geeking out over the latest innovations or decoding cryptic code snippets, you can find me exploring the intersections of art and science. "
+            "My curiosity is my superpower, and I'm here to help you harness yours too! "
+            "Let's explore the fascinating world of tech together, and make it a pleasure to learn."
+            "Tone: flirtatious, friendly, warm, accurate, approachable."
+        ),
+    )
+    TOOL_PROTOCOL_HINT = (
+        "Tool usage policy (strict):\n"
+        "• Available tools: browse (list a directory), read (preview a file), summarize (summarize a file), locate (find files by name).\n"
+        "• If you're asked for the location of a file or to look for one, the tool is \"locate\".\n"
+        "• If you're for information about a file's contents or to summarize it, the tool is \"summarize\".\n"
+        "• If you're asked to read a file, the tool is \"read\".\n"
+        "• If you're asked for a listing of the contents of a directory, the tool is \"browse\".\n"
+        "• args for browse: optional path (default '.'), optional pattern filter.\n"
+        "• args for read: required path.\n"
+        "• args for summarize: required path.\n"
+        "• args for locate: required path to query text.\n"
+        "• Call at most one tool per turn by replying with a single JSON object: {\"tool\": ..., \"tool_args\": {...}}.\n"
+        "• browse accepts optional path (default '.') and optional pattern filter.\n"
+        "• read and summarize require path. summarize first reads then condenses the content.\n"
+        "• locate accepts query text and searches under the allowlisted base.\n"
+        "• No prose, code fences, or extra keys in tool JSON. If no tool is needed, reply with plain text only."
+    )
+
+
+reload_from_environment()
+
+
+__all__ = [
+    "ALLOWLIST_LINE",
+    "BASE",
+    "DEFAULT_PERSONA",
+    "HOST",
+    "MODEL",
+    "TOOL_PROTOCOL_HINT",
+    "reload_from_environment",
+]

--- a/homeai/filesystem.py
+++ b/homeai/filesystem.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+from . import config
+
+
+def assert_in_allowlist(p: Path) -> Path:
+    base = config.BASE
+    p = p.resolve()
+    if not (p == base or base in p.parents):
+        raise PermissionError(f"Path {p} is outside allowlist base {base}")
+    return p
+
+
+def resolve_under_base(user_path: str) -> Path:
+    p = Path(os.path.expandvars(os.path.expanduser(user_path)))
+    if not p.is_absolute():
+        p = config.BASE / p
+    return assert_in_allowlist(p)
+
+
+def list_dir(path: str = ".", pattern: str = "") -> Dict[str, Any]:
+    root = resolve_under_base(path)
+    if not root.exists() or not root.is_dir():
+        return {"error": f"Not a directory: {root}"}
+    items = []
+    for entry in sorted(root.iterdir()):
+        name = entry.name
+        if pattern and pattern not in name:
+            continue
+        items.append(
+            {
+                "name": name,
+                "is_dir": entry.is_dir(),
+                "size": entry.stat().st_size if entry.is_file() else None,
+            }
+        )
+    return {"root": str(root), "count": len(items), "items": items}
+
+
+def read_text_file(path: str) -> Dict[str, Any]:
+    p = resolve_under_base(path)
+    if not p.exists() or not p.is_file():
+        return {"error": f"Not a file: {p}"}
+    try:
+        text = p.read_text(encoding="utf-8", errors="replace")
+    except Exception as exc:  # pragma: no cover - filesystem edge cases
+        return {"error": f"Read error: {exc}"}
+    max_chars = 60000
+    truncated = False
+    if len(text) > max_chars:
+        text = text[:max_chars]
+        truncated = True
+    return {"path": str(p), "truncated": truncated, "text": text}
+
+
+def locate_files(
+    query: str,
+    start: str = ".",
+    max_results: int = 200,
+    case_insensitive: bool = True,
+) -> Dict[str, Any]:
+    root = resolve_under_base(start)
+    if not root.exists() or not root.is_dir():
+        return {"error": f"Not a directory: {root}"}
+    normalized_query = query.casefold() if case_insensitive else query
+    results = []
+    for dirpath, _dirnames, filenames in os.walk(root):
+        for filename in filenames:
+            comparison_name = filename.casefold() if case_insensitive else filename
+            if normalized_query in comparison_name:
+                full = Path(dirpath) / filename
+                try:
+                    results.append(str(full.resolve()))
+                except Exception:
+                    results.append(str(full))
+                if len(results) >= max_results:
+                    return {
+                        "root": str(root),
+                        "query": query,
+                        "count": len(results),
+                        "truncated": True,
+                        "results": results,
+                    }
+    return {
+        "root": str(root),
+        "query": query,
+        "count": len(results),
+        "truncated": False,
+        "results": results,
+    }
+
+
+def get_file_info(p: str | os.PathLike[str]) -> Dict[str, Any]:
+    path = Path(p)
+    stat_result = path.stat()
+    return {
+        "path": str(path.resolve()),
+        "size": stat_result.st_size,
+        "mtime": int(stat_result.st_mtime),
+        "is_dir": path.is_dir(),
+        "name": path.name,
+    }
+
+
+__all__ = [
+    "assert_in_allowlist",
+    "get_file_info",
+    "list_dir",
+    "locate_files",
+    "read_text_file",
+    "resolve_under_base",
+]

--- a/homeai/model_engine.py
+++ b/homeai/model_engine.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+import time
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from . import config
+
+
+class LocalModelEngine:
+    def __init__(self, model: str | None = None, host: str | None = None) -> None:
+        selected_model = model or config.MODEL
+        selected_host = host or config.HOST
+        if not selected_host.startswith("http://") and not selected_host.startswith("https://"):
+            selected_host = "http://" + selected_host
+        self.model, self.host = selected_model, selected_host
+
+    def chat(self, messages: List[Dict[str, str]]) -> Dict[str, Any]:
+        msgs = [{"role": m["role"], "content": m["content"]} for m in messages]
+        payload_chat = {"model": self.model, "messages": msgs, "stream": False}
+        url_chat = f"{self.host}/api/chat"
+
+        used = "chat"
+        request_payload: Dict[str, Any] = payload_chat
+        t0 = time.perf_counter()
+
+        try:
+            response = requests.post(url_chat, json=payload_chat, timeout=120)
+        except requests.exceptions.RequestException as exc:
+            elapsed = time.perf_counter() - t0
+            meta = {
+                "endpoint": used,
+                "error": f"{exc.__class__.__name__}: {exc}",
+                "elapsed_sec": round(elapsed, 3),
+                "request": request_payload,
+            }
+            return {"text": f"Model request failed while calling {url_chat}: {exc}", "meta": meta}
+
+        if response.status_code == 404:
+            prompt = "\n".join([f"{m['role']}: {m['content']}" for m in messages])
+            payload_gen = {"model": self.model, "prompt": prompt, "stream": False}
+            used = "generate"
+            request_payload = payload_gen
+            try:
+                response = requests.post(f"{self.host}/api/generate", json=payload_gen, timeout=120)
+            except requests.exceptions.RequestException as exc:
+                elapsed = time.perf_counter() - t0
+                meta = {
+                    "endpoint": used,
+                    "error": f"{exc.__class__.__name__}: {exc}",
+                    "elapsed_sec": round(elapsed, 3),
+                    "request": request_payload,
+                    "fallback_from": "chat",
+                }
+                return {"text": f"Fallback request to {self.host}/api/generate failed: {exc}", "meta": meta}
+
+        elapsed = time.perf_counter() - t0
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as exc:
+            try:
+                response_body: Any = response.json()
+                response_preview = json.dumps(response_body, ensure_ascii=False)[:4000]
+            except ValueError:
+                response_body = None
+                response_preview = (response.text or "")[:4000]
+
+            meta = {
+                "endpoint": used,
+                "status": response.status_code,
+                "elapsed_sec": round(elapsed, 3),
+                "request": request_payload,
+                "error": f"{exc.__class__.__name__}: {exc}",
+            }
+            if response_body is not None:
+                meta["response"] = response_body
+            else:
+                meta["response_text"] = response_preview
+
+            reason = getattr(response, "reason", "") or ""
+            details = response_preview or reason or "No response body."
+            return {"text": f"Model endpoint {used} returned HTTP {response.status_code}: {details}", "meta": meta}
+
+        try:
+            data = response.json()
+        except Exception:
+            data = {"raw": response.text[:4000]}
+
+        text = ""
+        if isinstance(data, dict) and isinstance(data.get("message"), dict):
+            text = data["message"].get("content", "") or ""
+        if not text and isinstance(data, dict):
+            text = data.get("response", "") or ""
+
+        meta = {
+            "endpoint": used,
+            "status": response.status_code,
+            "elapsed_sec": round(elapsed, 3),
+            "request": request_payload,
+            "response": data,
+        }
+        return {"text": text, "meta": meta}
+
+
+__all__ = ["LocalModelEngine"]

--- a/homeai/tool_utils.py
+++ b/homeai/tool_utils.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+import re
+from typing import Any, Callable, Dict, Tuple
+
+
+class ToolRegistry:
+    """Simple registry mapping tool names to callables with keyword args."""
+
+    def __init__(self) -> None:
+        self.tools: Dict[str, Callable[..., Any]] = {}
+        self.aliases: Dict[str, str] = {}
+
+    def register(self, name: str, fn: Callable[..., Any]) -> None:
+        self.tools[name] = fn
+
+    def alias(self, alias_name: str, target_name: str) -> None:
+        if target_name not in self.tools:
+            raise ValueError(f"Cannot alias unknown tool '{target_name}'")
+        self.aliases[alias_name] = target_name
+
+    def _resolve_name(self, name: str) -> str:
+        if name in self.tools:
+            return name
+        if name in self.aliases:
+            return self.aliases[name]
+        if "." in name:
+            suffix = name.split(".")[-1]
+            if suffix in self.tools:
+                return suffix
+            if suffix in self.aliases:
+                return self.aliases[suffix]
+        return name
+
+    def run(self, name: str, args: Dict[str, Any] | None = None) -> Any:
+        resolved = self._resolve_name(name)
+        if resolved not in self.tools:
+            raise ValueError(f"Unknown tool: {name}")
+        return self.tools[resolved](**(args or {}))
+
+
+_BLOCK_RE = re.compile(r"\{[\s\S]*?\}")
+
+
+def parse_tool_call(text: str) -> Tuple[str | None, Dict[str, Any] | None]:
+    """Extract {"tool":..., "tool_args":...} from assistant text if present."""
+
+    if not text:
+        return None, None
+    match = _BLOCK_RE.search(text)
+    if not match:
+        return None, None
+    try:
+        obj = json.loads(match.group(0))
+    except json.JSONDecodeError:
+        return None, None
+    if not isinstance(obj, dict) or "tool" not in obj:
+        return None, None
+    args = obj.get("tool_args", {})
+    if isinstance(args, str):
+        args = {"path": args}
+    if not isinstance(args, dict):
+        return None, None
+    return str(obj["tool"]), args
+
+
+def parse_structured_tool_call(payload: Any) -> Tuple[str | None, Dict[str, Any] | None]:
+    """Extract the first tool call from a structured model response."""
+
+    if not isinstance(payload, dict):
+        return None, None
+
+    message = payload.get("message")
+    if isinstance(message, dict):
+        payload = message
+
+    tool_calls = payload.get("tool_calls") if isinstance(payload, dict) else None
+    if not tool_calls or not isinstance(tool_calls, list):
+        return None, None
+
+    first_call = tool_calls[0]
+    if not isinstance(first_call, dict):
+        return None, None
+
+    function_payload = first_call.get("function")
+    if not isinstance(function_payload, dict):
+        return None, None
+
+    tool_name = function_payload.get("name")
+    if not tool_name:
+        return None, None
+
+    raw_args = function_payload.get("arguments", {})
+    if isinstance(raw_args, str):
+        raw_args = raw_args.strip()
+        if raw_args:
+            try:
+                parsed_args = json.loads(raw_args)
+            except json.JSONDecodeError:
+                parsed_args = {"path": raw_args}
+        else:
+            parsed_args = {}
+    elif isinstance(raw_args, dict):
+        parsed_args = raw_args
+    else:
+        return str(tool_name), {}
+
+    if not isinstance(parsed_args, dict):
+        return str(tool_name), {}
+
+    return str(tool_name), parsed_args
+
+
+__all__ = [
+    "ToolRegistry",
+    "parse_tool_call",
+    "parse_structured_tool_call",
+]

--- a/homeai/ui_utils.py
+++ b/homeai/ui_utils.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Tuple
+
+
+def safe_component(
+    factory: Callable[..., Any],
+    *args: Any,
+    optional_keys: Tuple[str, ...] = ("live",),
+    **kwargs: Any,
+) -> Any:
+    """Instantiate a Gradio component, ignoring unsupported optional kwargs."""
+
+    attempt_kwargs = dict(kwargs)
+    while True:
+        try:
+            return factory(*args, **attempt_kwargs)
+        except TypeError as exc:
+            message = str(exc)
+            removed = False
+            for key in optional_keys:
+                if key in attempt_kwargs and f"'{key}'" in message:
+                    attempt_kwargs.pop(key)
+                    removed = True
+                    break
+            if not removed:
+                raise
+
+
+__all__ = ["safe_component"]


### PR DESCRIPTION
## Summary
- extract configuration, filesystem access, model engine, tool, and UI helpers into a dedicated `homeai` package
- update `homeai_app.py` to reload configuration, reuse the new helpers, and keep tool adapters small
- expose dynamic configuration accessors from `homeai.__init__` for other modules

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e5999b94d48328889399e6ebdf510f