### PR TITLE
Implement dependency injection and quality tooling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.8
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+      - id: ruff-format
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black

--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ HOMEAI_STORAGE=pg \
 
 ---
 
+## Architecture Overview
+
+See [`docs/architecture_overview.md`](docs/architecture_overview.md) for a component-level guide
+to the UI, tool adapters, model engine, and memory backends.
+
+---
+
 ## Testing
 
 Install the development extras and run the test suite from the project root:
@@ -122,6 +129,23 @@ Install the development extras and run the test suite from the project root:
 pip install -e .[dev]
 pytest
 ```
+
+---
+
+## Code Quality & Tooling
+
+- Install [`pre-commit`](https://pre-commit.com) hooks to run Ruff and Black automatically:
+
+  ```bash
+  pip install pre-commit
+  pre-commit install
+  ```
+
+- Run formatting and linting manually with:
+
+  ```bash
+  pre-commit run --all-files
+  ```
 
 ---
 

--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -1,0 +1,71 @@
+# HomeAI Architecture Overview
+
+This document summarises the runtime building blocks that make up HomeAI and how they
+collaborate during a typical chat session.
+
+## High-Level Flow
+
+1. **Gradio UI (`homeai_app.py`)** bootstraps dependencies through
+   `build_dependencies()` and wires the chat interface, preview panel, persona controls, and
+   event log.
+2. **Tool Registry** exposes browse/read/summarise/locate helpers backed by the hardened
+   filesystem APIs.
+3. **Model Engine** (`LocalModelEngine`) translates chat transcripts into requests against the
+   local model host and captures detailed telemetry for success and failure paths.
+4. **Memory Backends** persist each conversation turn and provide retrieval utilities used by the
+   context builder to compose prompts on subsequent interactions.
+
+The diagram below highlights the primary relationships:
+
+```
+User ↔ Gradio UI ↔ App Handlers
+                     │
+                     ├── Tool Registry ──▶ Filesystem utilities
+                     │
+                     ├── Model Engine ───▶ Local model HTTP API
+                     │
+                     └── Context Builder ─▶ Memory Backend (JSON or Postgres)
+```
+
+## Module Responsibilities
+
+### Gradio Application (`homeai_app.py`)
+
+* Declares dependency factories so tests and alternate deployments can inject custom engines,
+  memory stores, or tool registries.
+* Normalises tool outputs and handles persona metadata so every conversation begins with the
+  allowlist and protocol hints.
+* Maintains an event log summarising UI actions and model/tool results.
+
+### Filesystem Utilities (`homeai/filesystem.py`)
+
+* Enforce sandboxing via the configured project root and provide safe read/list/locate helpers.
+* Surface errors with descriptive messages that bubble back to the UI for display.
+
+### Model Engine (`homeai/model_engine.py`)
+
+* Wraps the local HTTP API, retrying against `/api/generate` when `/api/chat` is unavailable.
+* Captures structured metadata (endpoint, status code, request payload, elapsed time) to support
+  debugging and observability.
+
+### Memory and Context (`context_memory.py`)
+
+* `LocalJSONMemoryBackend` stores histories on disk with atomic writes and quarantine for
+  corrupted files.
+* `PgMemoryRepo` provides an optional Postgres implementation used when `HOMEAI_STORAGE=pg`.
+* `ContextBuilder` assembles persona + history + retrieval snippets, handling token budgeting and
+  duplicate suppression for the most recent user prompt.
+
+## Operational Considerations
+
+* Configure the storage backend via `HOMEAI_STORAGE` (`json` by default, `pg` for Postgres).
+* When running with Postgres, set `HOMEAI_PG_DSN` and optionally `HOMEAI_PG_SCHEMA`.
+* Code quality checks are automated via Ruff and Black (see the README for usage) and can be run
+  locally with `pre-commit run --all-files`.
+
+## Future Enhancements
+
+* Introduce shared logging configuration so UI, engine, and storage components emit structured
+  logs to the same sink.
+* Extend the architecture diagram with sequence diagrams for tool execution and context building
+  once additional integrations are added.

--- a/docs/best_practices_review.md
+++ b/docs/best_practices_review.md
@@ -1,0 +1,44 @@
+# HomeAI Best Practices Review
+
+## Overview
+The HomeAI canvas follows several strong engineering practices around modular design, configuration hygiene, and defensive file access. At the same time, there are a few areas where codifying conventions or extending automation would strengthen long-term maintainability. The sections below call out notable examples across the application shell, core libraries, packaging, testing, and documentation.
+
+## Application Shell (`homeai_app.py`)
+- **Tool adapters validate upstream helpers and normalize outputs** before registering them with the tool registry, surfacing filesystem errors as exceptions so the UI can report them cleanly.【F:homeai_app.py†L64-L145】
+- **Environment overrides are parsed defensively**—invalid integers are ignored instead of crashing startup—which aligns with robust configuration handling.【F:homeai_app.py†L152-L191】
+- **Persona seeding automatically injects allowlist and tool instructions,** reducing the chance that system prompts drift from security requirements.【F:homeai_app.py†L197-L205】
+- **Dependency factories expose overridable components,** letting tests or alternate deployments supply custom engines, registries, or memory backends without mutating module-level globals.【F:homeai_app.py†L114-L191】
+- **Gap:** Startup still eagerly builds a single dependency set—future work could accept command-line/environment toggles to lazily build only when the UI launches, avoiding import-time side effects for CLI utilities.
+
+## Core Libraries
+- **Filesystem sandboxing is consistently enforced**: resolving paths under the configured base raises `PermissionError` for outside access, list/read helpers surface explicit errors, and locate searches respect truncation limits.【F:homeai/filesystem.py†L10-L94】
+- **Memory persistence uses atomic writes and quarantines corrupt files,** preventing partial writes from corrupting on-disk history and moving unreadable files aside for inspection.【F:context_memory.py†L33-L44】【F:context_memory.py†L200-L230】
+- **The PostgreSQL repository validates dependencies, prepares schemas, and falls back gracefully** to an in-memory store when configuration is incomplete, keeping the app functional in minimal setups.【F:context_memory.py†L341-L498】
+- **Model calls capture rich error metadata** (endpoint, status, request payload, elapsed time) and implement a `/api/chat` → `/api/generate` fallback, aiding observability when hosts fail or change behaviour.【F:homeai/model_engine.py†L39-L125】
+- **Gap:** There is no shared logging configuration; modules default to the root logger. Supplying a structured logging setup (or integrating with the UI log panel) would align better with production observability practices.
+
+## Packaging & Scripts
+- **`pyproject.toml` clearly separates core, dev, and Postgres extras,** encouraging lean default installs while documenting optional tooling expectations.【F:pyproject.toml†L1-L28】
+- **The PostgreSQL bootstrapper validates required dependencies and offers a dry-run mode** so operators can confirm configuration before mutating databases.【F:scripts/bootstrap_postgres.py†L83-L139】
+- **Ruff and Black are now configured and automated via pre-commit,** keeping style checks consistent across contributors.【F:pyproject.toml†L29-L45】【F:.pre-commit-config.yaml†L1-L9】
+- **Gap:** Consider wiring quality checks into CI (e.g., GitHub Actions) so contributors get the same feedback signal as local hooks.
+
+## Testing
+- **Filesystem and tool behaviours are well covered** with fixtures that sandbox Gradio/requests imports and validate allowlist enforcement, truncation, and error paths.【F:tests/test_files_tools.py†L13-L193】
+- **Application intent parsing and UI event logging have regression tests** ensuring slash commands, environment overrides, and empty-model responses behave as expected.【F:tests/test_homeai_app.py†L4-L91】
+- **Memory backends guard against regressions** such as duplicate user prompts and corrupt on-disk state, keeping conversation history reliable.【F:tests/test_context_memory.py†L7-L41】
+- **Bootstrap scripting is validated via subprocess,** catching missing dependencies and verifying dry-run messaging.【F:tests/test_bootstrap_postgres_script.py†L18-L49】
+- **Model engine and Postgres repo now have integration-style tests** covering HTTP error handling, fallback behaviour, and database CRUD paths via a lightweight fake pool.【F:tests/test_model_engine.py†L1-L140】【F:tests/test_pg_memory_repo.py†L1-L147】
+- **Gap:** Running the Postgres repo tests against a real containerised database in CI would further increase confidence in SQL compatibility and schema creation.
+
+## Documentation
+- **The README provides end-to-end setup guidance** covering environment creation, model host expectations, PostgreSQL configuration, and runtime usage, which mirrors best practices for developer onboarding.【F:README.md†L1-L214】
+- **Supplemental docs cover memory plans and Postgres setup,** reinforcing infrastructure tasks beyond the main README.【F:docs/postgresql_setup.md†L1-L200】
+- **A new architecture overview summarises component responsibilities** and outlines operational considerations for deployments.【F:docs/architecture_overview.md†L1-L72】
+- **Gap:** Documenting observability/logging expectations (e.g., log sinks, metrics) would complement the architecture guide once a shared logging layer ships.
+
+## Recommendations
+1. Extend quality gates to CI (formatting, linting, tests, and eventually Postgres-in-container runs) so contributors share the same enforcement as local hooks.
+2. Add a centralised logging configuration that routes structured logs from the UI, engine, and storage layers to a common sink (and document the expected operators’ workflow).
+3. Expand operational runbooks with guidance on scaling the Postgres deployment (connection pooling, backup strategy, retention policies) to aid production adopters.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,3 +25,19 @@ postgres = [
 
 [tool.setuptools]
 packages = ["homeai"]
+
+[tool.black]
+line-length = 100
+target-version = ["py310"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+src = ["homeai", "tests", "scripts"]
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "N", "UP", "B"]
+ignore = ["E501"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["homeai"]

--- a/tests/test_pg_memory_repo.py
+++ b/tests/test_pg_memory_repo.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import replace
+from typing import Any, Dict, Iterable, List, Optional
+
+import pytest
+
+from context_memory import MemoryItem, PgMemoryRepo
+
+
+class _FakeSQLModule:
+    class SQL(str):
+        def format(self, identifier: "_FakeSQLModule.Identifier") -> "_FakeSQLModule.SQL":
+            return _FakeSQLModule.SQL(str(self).replace("{}", identifier.as_string()))
+
+    class Identifier:
+        def __init__(self, name: str) -> None:
+            self._name = name
+
+        def as_string(self) -> str:
+            return self._name
+
+
+class _FakeDB:
+    def __init__(self) -> None:
+        self.rows: Dict[str, Dict[str, Any]] = {}
+
+    def _record(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        record = {
+            "id": payload["id"],
+            "kind": payload["kind"],
+            "source": payload["source"],
+            "user_id": payload["user_id"],
+            "session_id": payload["session_id"],
+            "tags": json.loads(payload["tags"]),
+            "content": json.loads(payload["content"]),
+            "plain_text": payload["plain_text"],
+            "created_at": payload["created_at"],
+            "updated_at": payload["updated_at"],
+        }
+        existing = self.rows.get(record["id"])
+        if existing:
+            record["created_at"] = min(existing["created_at"], record["created_at"])
+        self.rows[record["id"]] = record
+        return dict(record)
+
+    def execute(self, query: str, params: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
+        normalized = " ".join(query.split()).strip().lower()
+        params = params or {}
+        if normalized.startswith("insert into"):
+            return [self._record(params)]
+        if "where id =" in normalized:
+            item_id = params.get("item_id")
+            row = self.rows.get(item_id)
+            return [dict(row)] if row else []
+        if "where session_id =" in normalized and "order by created_at" in normalized:
+            session_id = params.get("session_id")
+            rows = [dict(row) for row in self.rows.values() if row["session_id"] == session_id]
+            rows.sort(key=lambda r: r["created_at"])
+            return rows
+        if normalized.startswith("select session_id, max"):
+            summary: Dict[str, str] = {}
+            for row in self.rows.values():
+                sid = row["session_id"]
+                summary[sid] = max(summary.get(sid, ""), row["created_at"])
+            ordered = sorted(summary.items(), key=lambda it: it[1])
+            return [{"session_id": sid, "last_created": created} for sid, created in ordered]
+        if "plain_text ilike" in normalized:
+            tokens = [val.strip("% ").lower() for key, val in params.items() if key.startswith("tok_")]
+            session_id = params.get("session_id")
+            rows = [dict(row) for row in self.rows.values()]
+            results = []
+            for row in rows:
+                if session_id and row["session_id"] != session_id:
+                    continue
+                haystack = row["plain_text"].lower()
+                if all(tok in haystack for tok in tokens):
+                    results.append(row)
+            return results
+        if "order by created_at" in normalized:
+            session_id = params.get("session_id")
+            rows = [dict(row) for row in self.rows.values() if not session_id or row["session_id"] == session_id]
+            rows.sort(key=lambda r: r["created_at"])
+            return rows
+        if normalized.startswith("select"):
+            rows = [dict(row) for row in self.rows.values()]
+            if params.get("session_id"):
+                rows = [row for row in rows if row["session_id"] == params["session_id"]]
+            return rows
+        return []
+
+
+class _Cursor:
+    def __init__(self, db: _FakeDB):
+        self._db = db
+        self._rows: List[Dict[str, Any]] = []
+        self.description: List[Iterable[str]] = []
+
+    def __enter__(self) -> "_Cursor":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self._rows = []
+
+    def execute(self, query: str, params: Optional[Dict[str, Any]] = None) -> None:
+        self._rows = self._db.execute(query, params)
+        if self._rows:
+            self.description = [(key,) for key in self._rows[0].keys()]
+
+    def fetchone(self) -> Optional[Dict[str, Any]]:
+        return self._rows[0] if self._rows else None
+
+    def fetchall(self) -> List[Dict[str, Any]]:
+        return list(self._rows)
+
+
+class _Connection:
+    def __init__(self, db: _FakeDB):
+        self._db = db
+        self._homeai_schema_set = False
+
+    def cursor(self, row_factory=None) -> _Cursor:  # pragma: no cover - row_factory ignored intentionally
+        return _Cursor(self._db)
+
+    def execute(self, query: str, params: Optional[Dict[str, Any]] = None) -> None:
+        self._db.execute(query, params)
+
+
+class _ConnectionContext:
+    def __init__(self, db: _FakeDB):
+        self._db = db
+
+    def __enter__(self) -> _Connection:
+        return _Connection(self._db)
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        pass
+
+
+class _FakePool:
+    def __init__(self, *, conninfo: str, min_size: int, max_size: int, kwargs: Dict[str, Any]):
+        self.conninfo = conninfo
+        self.min_size = min_size
+        self.max_size = max_size
+        self.kwargs = kwargs
+        self._db = _FakeDB()
+
+    def wait(self) -> None:
+        return None
+
+    def connection(self) -> _ConnectionContext:
+        return _ConnectionContext(self._db)
+
+
+class _FakeRowsModule:
+    dict_row = object()
+
+
+class _FakePsycopgModule:
+    sql = _FakeSQLModule
+    rows = _FakeRowsModule
+
+
+@pytest.fixture(autouse=False)
+def fake_psycopg(monkeypatch):
+    modules = {
+        "psycopg": _FakePsycopgModule,
+        "psycopg.sql": _FakeSQLModule,
+        "psycopg.rows": _FakeRowsModule,
+        "psycopg_pool": type("psycopg_pool", (), {"ConnectionPool": _FakePool}),
+    }
+
+    with monkeypatch.context() as m:
+        for name, module in modules.items():
+            m.setitem(sys.modules, name, module)
+        yield
+
+
+def _build_item(session_id: str = "session") -> MemoryItem:
+    return MemoryItem(
+        id="item-1",
+        kind="note",
+        source="agent",
+        session_id=session_id,
+        plain_text="Important note",
+        content={"text": "Important note"},
+        tags=["tag"],
+    )
+
+
+def test_pg_repo_round_trip(fake_psycopg) -> None:
+    repo = PgMemoryRepo("postgresql://example", schema="public")
+
+    item = _build_item(session_id="alpha")
+    stored = repo.upsert(item)
+    assert stored.session_id == "alpha"
+
+    fetched = repo.get(item.id)
+    assert fetched is not None
+    assert fetched.plain_text == item.plain_text
+
+    search_hits = repo.search_text("important", filters={"session_id": "alpha"}, k=5)
+    assert [hit.id for hit in search_hits] == [item.id]
+
+    sessions = repo.list_session_ids()
+    assert "alpha" in sessions
+
+
+def test_pg_repo_updates_existing_rows(fake_psycopg) -> None:
+    repo = PgMemoryRepo("postgresql://example", schema="public")
+
+    first = _build_item(session_id="beta")
+    repo.upsert(first)
+
+    updated = replace(first, plain_text="Refined note", content={"text": "Refined note"})
+    repo.upsert(updated)
+
+    results = repo.list_session("beta")
+    assert len(results) == 1
+    assert results[0].plain_text == "Refined note"


### PR DESCRIPTION
## Summary
- add dependency factories in `homeai_app.py` so engines, registries, and memory backends can be overridden cleanly
- configure Ruff/Black with a shared pre-commit profile and document the workflow alongside an architecture overview
- extend automated coverage with HTTP error/fallback tests for `LocalModelEngine` and Postgres repo CRUD flows

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e5b0093b10832899e646ee63dc6443