### PR TITLE
Make vector auto-ingest opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ HOMEAI_CONTEXT_VECTOR_LIMIT=10           # retrieved semantic matches per turn
 HOMEAI_CONTEXT_MEMORY_LIMIT=8            # durable memory snippets per turn
 
 # Vector store ingestion (pgvector)
-HOMEAI_VECTOR_AUTO_INGEST=1              # set to 0/false to skip auto-scan on startup
+HOMEAI_VECTOR_AUTO_INGEST=1              # opt-in: enable repository auto-scan on startup
 HOMEAI_VECTOR_INGEST_PATHS=/path/one:/path/two  # optional override for allowlisted roots
 
 ```
@@ -272,10 +272,10 @@ limited by the model host and hardware.
 > those long responses *and* more chat history.
 
 When the pgvector store is enabled (install extras + set `HOMEAI_PG_DSN`), the
-app writes every chat turn to the `messages` table and, by default, pre-ingests
-files under the allowlisted base into `doc_chunks` on startup. Disable the scan
-with `HOMEAI_VECTOR_AUTO_INGEST=0` or supply specific roots via
-`HOMEAI_VECTOR_INGEST_PATHS`.
+app writes every chat turn to the `messages` table. You can opt-in to an
+automatic scan of allowlisted paths on startup by setting
+`HOMEAI_VECTOR_AUTO_INGEST=1`. Provide explicit roots with
+`HOMEAI_VECTOR_INGEST_PATHS` when enabling the scan.
 
 ---
 

--- a/homeai_app.py
+++ b/homeai_app.py
@@ -249,8 +249,13 @@ def _auto_ingest_repository(
     if store is None or embedder is None:
         return
 
-    enabled = os.getenv("HOMEAI_VECTOR_AUTO_INGEST", "1").strip().lower()
-    if enabled in {"0", "false", "no", "off"}:
+    flag = os.getenv("HOMEAI_VECTOR_AUTO_INGEST")
+    if flag is None:
+        # Opt-in behaviour: only scan when the user explicitly enables it.
+        return
+
+    enabled = flag.strip().lower()
+    if enabled not in {"1", "true", "yes", "on"}:
         return
 
     paths_env = os.getenv("HOMEAI_VECTOR_INGEST_PATHS", "").strip()


### PR DESCRIPTION
## Summary
- require the HOMEAI_VECTOR_AUTO_INGEST environment variable to be set to a truthy value before running the startup repository scan
- document the new opt-in behaviour for auto ingestion in the README

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e5db794cb08328a0c479b35ab22176