### PR TITLE
Update embedding warmup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,12 @@ sure Ollama has the configured embedding model available (defaults to
 
 ```bash
 ollama pull mini-lm-embedding
-ollama run mini-lm-embedding --keep-alive 30m  # keep the embedder warm
+# Warm the embedder and extend its keep-alive window via the /api/embed endpoint
+curl http://127.0.0.1:11434/api/embed -d '{
+  "model": "mini-lm-embedding",
+  "input": "warmup",
+  "keep_alive": "30m"
+}'
 ```
 
 If you change `HOMEAI_EMBEDDING_MODEL`, download and run the corresponding


### PR DESCRIPTION
## Summary
- replace the outdated `ollama run ... --keep-alive` example with a curl request against `/api/embed`
- note how to set the `keep_alive` window when warming the embedding model

## Testing
- not run (documentation change)


------
https://chatgpt.com/codex/tasks/task_e_68e5e2c58f8c83288aae4e445e327143