### PR TITLE
Document Postgres vector resizing when changing embedding model

### DIFF
--- a/docs/postgresql_setup.md
+++ b/docs/postgresql_setup.md
@@ -148,7 +148,12 @@ The migration creates the `doc_chunks` and `messages` tables, enables the
 (change to HNSW if your PostgreSQL version supports it and you prefer that
 trade-off).  Adjust the index parameters and embedding dimension to match the
 embedding model configured via `HOMEAI_EMBEDDING_MODEL` and
-`HOMEAI_EMBEDDING_DIMENSION`.
+`HOMEAI_EMBEDDING_DIMENSION`. If you later switch to an embedding model with a
+different vector dimensionality (for example, moving from a 768-dimension model
+to `mxbai-embed-large` at 1024 dimensions), you must alter the PostgreSQL
+columns that store embeddings (e.g., `ALTER TABLE ... ALTER COLUMN embedding TYPE
+vector(1024)`) so that their declared dimension matches the new model before
+ingesting additional data.
 
 Once the migration is applied and the app is started with `HOMEAI_PG_DSN`
 configured, HomeAI will automatically ingest files under the configured


### PR DESCRIPTION
## Summary
- note that pgvector columns must be altered to match the configured embedding dimension when switching models
- provide an example ALTER TABLE statement for resizing embedding vectors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e661f1be9083288f1c28bc31a8d1ce