### PR TITLE
Enable vector-backed memory retrieval

### DIFF
--- a/homeai_app.py
+++ b/homeai_app.py
@@ -291,8 +291,9 @@ def build_dependencies(
 ) -> AppDependencies:
     tool_reg = _register_default_tools(registry or ToolRegistry())
     engine_instance = engine_factory() if engine_factory else LocalModelEngine()
-    backend, builder = _build_memory_components(storage=storage, overrides=context_overrides)
     embedder, store = _build_vector_components()
+    backend, builder = _build_memory_components(storage=storage, overrides=context_overrides)
+    backend.configure_vector_search(store, embedder=embedder)
     _auto_ingest_repository(store, embedder)
     return AppDependencies(
         tool_registry=tool_reg,


### PR DESCRIPTION
## Summary
- teach the local memory backend to query the vector store for semantic recall with a lexical fallback
- wire the vector store into dependency construction so chat history searches can use embeddings
- add a regression test that covers the vector search pathway

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e6655615188328bb2dddc790ab886a