### PR TITLE
Fix new conversation ID reuse for persisted sessions

### DIFF
--- a/context_memory.py
+++ b/context_memory.py
@@ -889,7 +889,10 @@ class LocalJSONMemoryBackend:
         self._known_conversation_ids: List[str] = []
         initial_sessions = self.repo.list_session_ids()
         self._known_conversation_ids.extend(initial_sessions)
-        self._issued_conversation_ids: set[str] = set()
+        # Treat conversations already present in the repository as issued so
+        # that ``new_conversation_id`` always returns a fresh identifier when
+        # the application starts with existing sessions on disk.
+        self._issued_conversation_ids: set[str] = set(initial_sessions)
         self._primary_conversation_id = self._select_primary_conversation_id()
         self._register_conversation_id(self._primary_conversation_id)
 

--- a/tests/test_context_memory.py
+++ b/tests/test_context_memory.py
@@ -60,6 +60,21 @@ def test_new_conversation_ids_are_unique(tmp_path):
     assert second in known
 
 
+def test_new_conversation_skips_existing_sessions(tmp_path):
+    backend = LocalJSONMemoryBackend(base_dir=tmp_path)
+    first = backend.new_conversation_id()
+    backend.add_message(first, "user", {"text": "hello"})
+
+    # Simulate a fresh process by creating a new backend pointing at the same
+    # repository. ``new_conversation_id`` should not reuse the persisted ID.
+    restarted = LocalJSONMemoryBackend(base_dir=tmp_path)
+    new_id = restarted.new_conversation_id()
+
+    assert new_id != first
+    assert new_id not in {"", None}
+    assert new_id.startswith("conversation")
+
+
 def test_set_active_conversation_registers_id(tmp_path):
     backend = LocalJSONMemoryBackend(base_dir=tmp_path)
 


### PR DESCRIPTION
## Summary
- seed LocalJSONMemoryBackend's issued conversation IDs with any sessions already stored in the repository to avoid reusing them
- add regression test covering restart scenario to ensure new conversations skip existing session IDs

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e67590590083289f2ad4ef51dbc3a9