### PR TITLE
Ensure filesystem metadata queries respect allowlist

### DIFF
--- a/homeai/filesystem.py
+++ b/homeai/filesystem.py
@@ -95,7 +95,9 @@ def locate_files(
 
 
 def get_file_info(p: str | os.PathLike[str]) -> Dict[str, Any]:
-    path = Path(p)
+    """Return metadata for ``p`` after enforcing the allowlist."""
+
+    path = resolve_under_base(os.fspath(p))
     stat_result = path.stat()
     return {
         "path": str(path.resolve()),

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+
+from homeai import filesystem
+
+
+def test_get_file_info_enforces_allowlist(tmp_path, monkeypatch):
+    base = tmp_path / "base"
+    base.mkdir()
+    allowed_file = base / "note.txt"
+    allowed_file.write_text("hello")
+
+    monkeypatch.setattr(filesystem.config, "BASE", base.resolve())
+
+    info = filesystem.get_file_info("note.txt")
+    assert info["path"] == str(allowed_file.resolve())
+    assert info["size"] == len("hello")
+    assert not info["is_dir"]
+
+    outside_root = tmp_path / "outside"
+    outside_root.mkdir()
+    outside_file = outside_root / "secret.txt"
+    outside_file.write_text("nope")
+
+    with pytest.raises(PermissionError):
+        filesystem.get_file_info(outside_file)
+
+
+def test_get_file_info_missing_file(tmp_path, monkeypatch):
+    base = tmp_path / "workspace"
+    base.mkdir()
+
+    monkeypatch.setattr(filesystem.config, "BASE", base.resolve())
+
+    with pytest.raises(FileNotFoundError):
+        filesystem.get_file_info("missing.txt")
+


### PR DESCRIPTION
## Summary
- enforce the repository allowlist when collecting file metadata
- add regression coverage for allowlist enforcement and missing-file handling

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e6822162d48328ba5184ebff8d171b