### PR TITLE
Add OS-specific installation guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,32 @@ If you change `HOMEAI_EMBEDDING_MODEL`, download and run the corresponding
 Ollama model instead.  Chat completions continue to use
 `HOMEAI_MODEL_NAME` (default `gpt-oss:20b`).
 
+---
+
+## Platform-specific installation guides
+
+Choose the operating-system guide that matches your environment for a
+step-by-step walkthrough covering prerequisites, Python environment creation,
+and PostgreSQL configuration:
+
+- [Linux installation guide](docs/install_linux.md)
+- [macOS installation guide](docs/install_macos.md)
+- [Windows installation guide](docs/install_windows.md)
+
+Each guide includes notes on when to use the optional PostgreSQL backend and how
+to integrate local model hosts such as Ollama or LM Studio.
+
+### Distribution considerations
+
+The project currently ships as source with editable installs (`pip install -e .`)
+so that Python environments remain transparent and debuggable on all platforms.
+Automated installers (shell scripts, packaged apps, or platform-specific
+bundles) are possible, but they add maintenance overhead for vendor-specific GPU
+drivers, PostgreSQL binaries, and code-signing requirements. When a stable 1.0
+release is available, revisit options such as publishing to PyPI, creating a
+`pipx`-friendly package, or shipping per-OS bootstrap scripts that orchestrate
+the steps documented above.
+
 ### 4) Run the app
 
 ```bash

--- a/docs/install_linux.md
+++ b/docs/install_linux.md
@@ -1,0 +1,132 @@
+# Linux Installation Guide
+
+This guide describes how to install and run HomeAI on Ubuntu 24.04 LTS. The
+steps also apply to most Debian-based distributions with small changes to the
+package manager commands. For Fedora, Arch, and other Linux flavours, use their
+respective package managers but keep the same Python and PostgreSQL versions.
+
+## 1. System preparation
+
+1. Update package metadata and install the Python build tooling used by the
+   project:
+
+   ```bash
+   sudo apt update
+   sudo apt install -y python3 python3-venv python3-pip build-essential
+   ```
+
+2. (Optional) Install Git if you plan to clone the repository:
+
+   ```bash
+   sudo apt install -y git
+   ```
+
+3. Install GPU drivers and CUDA tooling if you intend to run large local models.
+   Refer to your GPU vendor's documentation for the exact steps.
+
+## 2. Obtain the source code
+
+Clone the repository (or download a release archive) into your preferred
+workspace:
+
+```bash
+git clone https://github.com/your-org/HomeAI.git
+cd HomeAI
+```
+
+## 3. Create a Python environment
+
+HomeAI targets Python 3.10 or newer. Create an isolated virtual environment so
+that system packages stay untouched:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -e .
+```
+
+To enable the optional PostgreSQL backend, install the extra dependencies
+instead:
+
+```bash
+pip install -e .[postgres]
+```
+
+For development or contributing, install all tooling with:
+
+```bash
+pip install -e .[dev]
+```
+
+## 4. Configure model access
+
+HomeAI talks to a local model host that exposes `/api/chat` (and optionally
+`/api/generate`). Popular choices on Linux include [Ollama](https://ollama.ai/)
+and [lmstudio.ai](https://lmstudio.ai/). Install and configure your preferred
+runtime, then set these environment variables:
+
+```bash
+export HOMEAI_MODEL_HOST=http://127.0.0.1:11434
+export HOMEAI_MODEL_NAME=gpt-oss:20b
+export HOMEAI_ALLOWLIST_BASE="$HOME"
+```
+
+Adjust the host URL and model name to match the backend you installed.
+
+## 5. Optional: PostgreSQL backend
+
+The application ships with a JSON file store by default. To enable durable
+memory, install PostgreSQL 16+ with the `pgvector` and `pg_trgm` extensions.
+
+```bash
+sudo apt install -y postgresql postgresql-contrib postgresql-16-pgvector
+```
+
+Use the helper script to create the database, role, and tables:
+
+```bash
+source .venv/bin/activate
+POSTGRES_SUPERUSER=postgres \
+POSTGRES_SUPERUSER_PASSWORD='your-postgres-password' \
+HOMEAI_DB_PASSWORD='your-app-password' \
+python scripts/bootstrap_postgres.py
+```
+
+Alternatively, follow the detailed walkthrough in
+[`docs/postgresql_setup.md`](postgresql_setup.md) for manual steps. After
+provisioning, configure the DSN and storage backend:
+
+```bash
+export HOMEAI_PG_DSN=postgresql://homeai:your-app-password@127.0.0.1:5432/homeai
+export HOMEAI_STORAGE=pg
+```
+
+Apply the optional semantic-search migration if you plan to use embeddings:
+
+```bash
+psql "$HOMEAI_PG_DSN" -f migrations/001_create_vector_store.sql
+```
+
+## 6. Launch HomeAI
+
+Run the application from the project root with the virtual environment active:
+
+```bash
+python homeai_app.py
+```
+
+The Gradio UI becomes available at http://127.0.0.1:7860. When using the
+PostgreSQL backend, ensure `HOMEAI_STORAGE=pg` and `HOMEAI_PG_DSN` are exported
+before starting the app.
+
+## 7. Next steps and automation
+
+- Add the environment exports to your shell profile (e.g., `~/.bashrc`) so they
+  persist between sessions.
+- Use `systemd` user services or tools like `tmux` to keep the server running in
+  the background.
+- For scripted deployments, wrap the steps above in an internal shell script.
+  Publishing a fully automated installer is possible but requires maintaining
+  OS-specific branches for drivers and package names; the documented manual flow
+  keeps the setup transparent and debuggable.

--- a/docs/install_macos.md
+++ b/docs/install_macos.md
@@ -1,0 +1,144 @@
+# macOS Installation Guide
+
+The following steps target macOS 13 Ventura or newer on Apple Silicon hardware.
+Intel-based Macs can follow the same flow but may require Rosetta 2 for some
+third-party binaries. Use Terminal.app or your preferred shell.
+
+## 1. Install command-line tools and Homebrew
+
+1. Install Apple's Command Line Tools (provides Git, compilers, and SDKs):
+
+   ```bash
+   xcode-select --install
+   ```
+
+2. Install [Homebrew](https://brew.sh/) if it is not already present:
+
+   ```bash
+   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+   ```
+
+   Follow the on-screen prompts, then add Homebrew to your shell profile. For
+   `zsh` (the default shell on macOS):
+
+   ```bash
+   echo 'eval "$($(brew --prefix)/bin/brew shellenv)"' >> ~/.zprofile
+   eval "$($(brew --prefix)/bin/brew shellenv)"
+   ```
+
+## 2. Install prerequisites
+
+Use Homebrew to install Python 3.11 (or newer), Git, and PostgreSQL if you plan
+on using the optional database backend:
+
+```bash
+brew update
+brew install python@3.11 git
+```
+
+If you need PostgreSQL with the `vector` extension:
+
+```bash
+brew install postgresql@16 pgvector
+brew services start postgresql@16
+```
+
+Homebrew adds the `pgvector` files automatically. To keep `psql` and
+`pg_config` on your path, add the PostgreSQL bin directory to your shell
+profile:
+
+```bash
+echo 'export PATH="/opt/homebrew/opt/postgresql@16/bin:$PATH"' >> ~/.zprofile
+source ~/.zprofile
+```
+
+## 3. Obtain the source code
+
+Clone the repository and enter it:
+
+```bash
+git clone https://github.com/your-org/HomeAI.git
+cd HomeAI
+```
+
+## 4. Create a Python virtual environment
+
+Use the Homebrew-installed Python to create and activate a virtual environment:
+
+```bash
+/opt/homebrew/bin/python3.11 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -e .
+```
+
+Install extras depending on your use case:
+
+- PostgreSQL backend: `pip install -e .[postgres]`
+- Development tooling: `pip install -e .[dev]`
+
+## 5. Configure the model backend
+
+macOS users commonly run [Ollama](https://ollama.ai/) or
+[LM Studio](https://lmstudio.ai/). Install your preferred runtime and confirm it
+serves `http://127.0.0.1:11434` (Ollama's default). Export the required
+variables in your shell profile or session:
+
+```bash
+export HOMEAI_MODEL_HOST=http://127.0.0.1:11434
+export HOMEAI_MODEL_NAME=gpt-oss:20b
+export HOMEAI_ALLOWLIST_BASE="$HOME"
+```
+
+For embedding support, pull the `mxbai-embed-large` model in Ollama:
+
+```bash
+ollama pull mxbai-embed-large
+```
+
+## 6. Optional: PostgreSQL configuration
+
+If you installed PostgreSQL via Homebrew, run the bootstrap helper to create the
+application role and database:
+
+```bash
+source .venv/bin/activate
+POSTGRES_SUPERUSER=postgres \
+HOMEAI_DB_PASSWORD='your-app-password' \
+HOMEAI_PG_DSN=postgresql://homeai:your-app-password@127.0.0.1:5432/homeai \
+python scripts/bootstrap_postgres.py
+```
+
+Homebrew's PostgreSQL service uses password-less local connections by default,
+so you usually do not need to set `POSTGRES_SUPERUSER_PASSWORD`. After running
+the script, enable the backend by exporting:
+
+```bash
+export HOMEAI_PG_DSN=postgresql://homeai:your-app-password@127.0.0.1:5432/homeai
+export HOMEAI_STORAGE=pg
+```
+
+Apply the optional vector-store migration if desired:
+
+```bash
+psql "$HOMEAI_PG_DSN" -f migrations/001_create_vector_store.sql
+```
+
+## 7. Launch HomeAI
+
+From the project root with the virtual environment activated:
+
+```bash
+python homeai_app.py
+```
+
+The Gradio UI opens at http://127.0.0.1:7860. Stop the server with `Ctrl+C`.
+
+## 8. Notes on automation and packaging
+
+- macOS users can create an Automator or LaunchAgent job that activates the
+  virtual environment and starts `homeai_app.py` at login.
+- A future standalone installer could bundle Python and dependencies via
+  [`pyapp`](https://ofek.dev/pyapp/) or [`shiv`](https://shiv.readthedocs.io/),
+  but keeping the Homebrew-based workflow provides transparency and easier
+  debugging during active development.

--- a/docs/install_windows.md
+++ b/docs/install_windows.md
@@ -1,0 +1,144 @@
+# Windows Installation Guide
+
+These instructions target Windows 11 with administrator access. Windows 10 works
+with the same steps as long as you install Python 3.10+ and recent Visual C++
+build tools. Commands can be run inside **Windows Terminal** using PowerShell.
+
+## 1. Install prerequisites
+
+1. **Python 3.11+** – install from the Microsoft Store or from
+   [python.org](https://www.python.org/downloads/windows/). When using the MSI
+   installer, ensure that you check **"Add Python to PATH"**.
+
+2. **Git** – install via [https://git-scm.com/download/win](https://git-scm.com/download/win)
+   or with Winget:
+
+   ```powershell
+   winget install --id Git.Git -e --source winget
+   ```
+
+3. **Microsoft Visual C++ Build Tools** (for compiling Python wheels that ship
+   as source). Install from
+   [https://visualstudio.microsoft.com/visual-cpp-build-tools/](https://visualstudio.microsoft.com/visual-cpp-build-tools/)
+   and include the "Desktop development with C++" workload.
+
+4. (Optional) **PostgreSQL 16+ with pgvector** – download the EnterpriseDB
+   installer from [https://www.postgresql.org/download/windows/](https://www.postgresql.org/download/windows/)
+   or install via Winget:
+
+   ```powershell
+   winget install --id PostgreSQL.PostgreSQL -e --source winget
+   ```
+
+   During installation:
+
+   - Set a memorable superuser password for the `postgres` account.
+   - Enable the `pgvector` extension (available in the StackBuilder component
+     list). If StackBuilder is not installed, download the Windows pgvector
+     binaries from the official release page and copy them into the PostgreSQL
+     `lib` and `share/extension` directories.
+
+5. (Optional) **Ollama** – run the official Windows installer from
+   [https://ollama.ai/download](https://ollama.ai/download) to host the default
+   chat and embedding models locally.
+
+## 2. Clone the repository
+
+Open a new PowerShell session and run:
+
+```powershell
+git clone https://github.com/your-org/HomeAI.git
+cd HomeAI
+```
+
+## 3. Create a virtual environment
+
+Use the Python launcher to create and activate a virtual environment inside the
+project:
+
+```powershell
+py -3.11 -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+pip install -e .
+```
+
+To enable PostgreSQL support, install the extras after activation:
+
+```powershell
+pip install -e .[postgres]
+```
+
+For development tooling, run `pip install -e .[dev]`.
+
+## 4. Configure the model backend
+
+Ensure your local model host is running and reachable. When using Ollama's
+default port, export the required environment variables in PowerShell:
+
+```powershell
+$env:HOMEAI_MODEL_HOST = "http://127.0.0.1:11434"
+$env:HOMEAI_MODEL_NAME = "gpt-oss:20b"
+$env:HOMEAI_ALLOWLIST_BASE = "$env:USERPROFILE"
+```
+
+If you plan to use embeddings, download the model once:
+
+```powershell
+ollama pull mxbai-embed-large
+```
+
+## 5. Optional: PostgreSQL configuration
+
+After installing PostgreSQL, open a PowerShell session with the virtual
+environment activated and run the bootstrap helper (adjust the passwords to your
+values):
+
+```powershell
+$env:POSTGRES_SUPERUSER = "postgres"
+$env:POSTGRES_SUPERUSER_PASSWORD = "your-postgres-password"
+$env:HOMEAI_DB_PASSWORD = "your-app-password"
+python scripts/bootstrap_postgres.py
+```
+
+The script creates the `homeai` role, database, and the `homeai_memory` table
+with indexes. When it finishes, set the DSN and enable the PostgreSQL backend:
+
+```powershell
+$env:HOMEAI_PG_DSN = "postgresql://homeai:your-app-password@127.0.0.1:5432/homeai"
+$env:HOMEAI_STORAGE = "pg"
+```
+
+To install the semantic-search schema:
+
+```powershell
+psql "$env:HOMEAI_PG_DSN" -f migrations/001_create_vector_store.sql
+```
+
+If `psql` is not on your PATH, add the PostgreSQL `bin` directory (for example,
+`C:\\Program Files\\PostgreSQL\\16\\bin`) to the system PATH via System
+Properties → Environment Variables.
+
+## 6. Launch HomeAI
+
+Start the application from the project root with the virtual environment active:
+
+```powershell
+python homeai_app.py
+```
+
+The Gradio UI runs at http://127.0.0.1:7860. Use `Ctrl+C` in the terminal to
+stop the server.
+
+## 7. Tips for Windows automation
+
+- Create a PowerShell script that activates the environment, exports the needed
+  variables, and launches the app. Pin it to Start or schedule it with Task
+  Scheduler for one-click startup.
+- For services that should persist in the background, run HomeAI from a Windows
+  Subsystem for Linux (WSL) distribution or use third-party tools like
+  [nssm](https://nssm.cc/) to wrap the script as a Windows service.
+- Publishing a single "downloadable installer" similar to Ollama is feasible but
+  requires bundling Python, managing antivirus false positives, and ensuring the
+  embedded PostgreSQL binaries stay updated. The documented manual steps keep the
+  setup maintainable while the project evolves.


### PR DESCRIPTION
## Summary
- add dedicated installation guides for Linux, macOS, and Windows
- link the new guides from the README and document distribution considerations

## Testing
- not run (documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e684d0bda4832899471316957247ca